### PR TITLE
Fix escaped css

### DIFF
--- a/templates/source/components/Document/index.js
+++ b/templates/source/components/Document/index.js
@@ -23,7 +23,7 @@ export default ({
       {head.title.toComponent()}
       {head.meta.toComponent()}
       {renderStyles(styles)}
-      <style>{cxsync.css || ''}</style>
+      <style dangerouslySetInnerHTML={{ __html: cxsync.css || '' }} />
       <script dangerouslySetInnerHTML=\{{
         __html: `
           (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
**Problem**

If you have cxs that contains child selectors (e.g. '.class > div'), the '>' is escaped causing a flash of weird styling anywhere where this is used before the JS kicks in client side and corrects it.

**Solution**

Use dangerouslySetInnerHTML to spit out all the rules so they aren't escaped.
