### PR TITLE
Allow specifying repo owner

### DIFF
--- a/src/generators/project/index.js
+++ b/src/generators/project/index.js
@@ -4,6 +4,12 @@ import createGitHubRepo from '../../lib/github'
 const cwd = process.cwd()
 const templatesDir = '../templates'
 
+const inputExists = (value) => (
+  value && value.trim()
+    ? true
+    : 'Project name is required.'
+)
+
 export const renderTemplateActions = (data, templateFiles) => (
   templateFiles.map(templateFile => ({
     type: 'add',
@@ -20,12 +26,7 @@ export default plop => {
       type: 'input',
       name: 'name',
       message: 'What is your project called?',
-      validate: value => {
-        if (value && value.trim()) {
-          return true
-        }
-        return 'Project name is required.'
-      }
+      validate: inputExists
     }, {
       type: 'input',
       name: 'description',
@@ -65,6 +66,11 @@ export default plop => {
       name: 'repoPublic',
       message: 'Should this repo be public (MIT licensed if so)?',
       default: false
+    }, {
+      when: (answers) => answers.repo,
+      type: 'input',
+      name: 'repoOwner',
+      message: 'What org or user should this repo be created under (blank for self)?'
     }],
     actions: data => ([
       ...renderTemplateActions(data, [

--- a/src/lib/github/index.js
+++ b/src/lib/github/index.js
@@ -2,13 +2,14 @@ import changeCase from 'change-case'
 import GitHubApi from 'github'
 import gitCmd from 'simple-git/promise'
 
-const org = 'everydayhero'
-
-const initialCommit = (name) => {
+const initialCommit = ({
+  name,
+  owner
+}) => {
   const git = gitCmd(process.cwd())
 
   return git.init()
-    .then(() => git.addRemote('origin', `git@github.com:${org}/${name}.git`))
+    .then(() => git.addRemote('origin', `git@github.com:${owner}/${name}.git`))
     .then(() => git.add(['.']))
     .then(() => git.commit('Initial commit'))
     .then(() => git.push('origin', 'master'))
@@ -18,22 +19,43 @@ const initialCommit = (name) => {
 export default (data) => {
   const github = new GitHubApi({
     protocol: 'https',
-    Promise: Promise,
+    Promise,
     timeout: 5000
   })
 
-  const name = changeCase.paramCase(data.name)
+  const repoConfig = {
+    name: changeCase.paramCase(data.name),
+    has_wiki: false,
+    private: !data.repoPublic,
+    description: data.description
+  }
 
   github.authenticate({
     type: 'token',
     token: process.env.BRM_GITHUB_API_TOKEN
   })
 
-  return github.repos.createForOrg({
-    org,
-    name,
-    has_wiki: false,
-    private: !data.repoPublic,
-    description: data.description
-  }).then(() => initialCommit(name))
+  const createOrgRepo = (org) => (
+    github.repos.createForOrg({
+      ...repoConfig,
+      org
+    }).then(() => (org))
+  )
+
+  const createUserRepo = () => (
+    Promise.all([
+      github.users.get({})
+        .then(({ login }) => (login)),
+      github.repos.create(repoConfig)
+    ]).then(([user]) => user)
+  )
+
+  const createRepo = data.repoOwner
+    ? createOrgRepo(data.repoOwner)
+    : createUserRepo()
+
+  return createRepo.then((owner) => initialCommit({
+    owner,
+    name: repoConfig.name
+  }))
 }


### PR DESCRIPTION
Removes the 'everydayhero' default. Has some beautiful ternaries and Promise grouping due to personal repo creation requiring a second call to GitHub API.