### PR TITLE
Use create store for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generator for Boiler Room projects",
   "main": "index.js",
   "bin": {

--- a/templates/source/client.js
+++ b/templates/source/client.js
@@ -2,7 +2,7 @@ import React from 'react'
 import routes from './routes'
 import { createClient } from 'boiler-room-runner'
 import { render } from 'react-dom'
-import configureStore from './store'
+import createStore from './store'
 import 'minimal.css'
 
 if (typeof Promise === 'undefined') {
@@ -11,7 +11,7 @@ if (typeof Promise === 'undefined') {
 
 const basepath = process.env.BASE_PATH
 const initialState = JSON.parse(document.getElementById('initial-state').innerHTML)
-const store = configureStore(initialState)
+const store = createStore(initialState)
 const App = createClient({ basepath, routes, store })
 
 render(<App />, document.getElementById('mount'))

--- a/templates/source/server.js
+++ b/templates/source/server.js
@@ -2,10 +2,9 @@ import { createServer } from 'boiler-room-runner'
 {{#if constructicon}}
 import renderDocument from 'constructicon/lib/renderDocument'
 {{/if}}
-import configureStore from './store'
+import createStore from './store'
 import routes from './routes'
 
-const store = configureStore()
 const basepath = process.env.BASE_PATH
 
 export default ({ assets }) => {
@@ -15,7 +14,7 @@ export default ({ assets }) => {
     renderDocument,
     {{/if}}
     routes,
-    store,
+    createStore,
     assets
   })
 


### PR DESCRIPTION
Solve the issue we had with MyGames, which could be an issue across the board for us in other projects, where the store was being persisted across requests, so we need to pass through `createStore` to `createServer`, rather than in a store instance.